### PR TITLE
Allow usage with Awestruct 0.6.x(alpha)

### DIFF
--- a/awestruct-ibeams.gemspec
+++ b/awestruct-ibeams.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'awestruct', '~> 0.5.6'
+  spec.add_dependency 'awestruct', '>= 0.5.6', '< 0.7.0'
   spec.add_dependency 'naturally', '~> 2.1.0'
 end

--- a/lib/awestruct/ibeams/version.rb
+++ b/lib/awestruct/ibeams/version.rb
@@ -1,5 +1,5 @@
 module Awestruct
   module Ibeams
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
   end
 end


### PR DESCRIPTION
This allows using ibeams with newer Awestruct. Upstream PRs include
* https://github.com/awestruct/awestruct/pull/518
* https://github.com/awestruct/awestruct/pull/539
Potentially allows using the next version with https://github.com/awestruct/awestruct/pull/543 merged.