### PR TITLE
Fix failing spec: section_anchor should replace spaces with -

### DIFF
--- a/lib/awestruct/ibeams/asciidoc_sections.rb
+++ b/lib/awestruct/ibeams/asciidoc_sections.rb
@@ -99,7 +99,7 @@ module Awestruct
 
         return [
           prefix,
-          title.tr_s(separator, separator).chomp(separator),
+          title.tr_s(" ", separator).chomp(separator),
         ].join('')
       end
     end

--- a/lib/awestruct/ibeams/asciidoc_sections.rb
+++ b/lib/awestruct/ibeams/asciidoc_sections.rb
@@ -99,7 +99,7 @@ module Awestruct
 
         return [
           prefix,
-          title.tr_s(" ", separator).chomp(separator),
+          title.tr_s(" ._-", separator).chomp(separator),
         ].join('')
       end
     end


### PR DESCRIPTION
I'm new to ruby, but `tr_s` with two identical arguments looks suspicious. The version implemented in this PR passes the failing spec.