### PR TITLE
asciidoc-sections: strip separator prefix from section anchor link

### DIFF
--- a/lib/awestruct/ibeams/asciidoc_sections.rb
+++ b/lib/awestruct/ibeams/asciidoc_sections.rb
@@ -99,7 +99,7 @@ module Awestruct
 
         return [
           prefix,
-          title.tr_s(" ._-", separator).chomp(separator),
+          title.tr_s(" ._-", separator).chomp(separator).delete_prefix(separator),
         ].join('')
       end
     end

--- a/spec/awestruct/ibeams/asciidoc_sections_spec.rb
+++ b/spec/awestruct/ibeams/asciidoc_sections_spec.rb
@@ -45,6 +45,12 @@ describe Awestruct::IBeams::AsciidocSections do
           pipeline.section_anchor('RSpec!', doc)
         ).to eql('rspec')
       end
+
+      it 'should delete leading separator' do
+        expect(
+          pipeline.section_anchor('<code>deleteDir</code>: Recursively delete the current directory from the workspace', doc)
+        ).to eql('deletedir-recursively-delete-the-current-directory-from-the-workspace')
+      end
     end
 
 


### PR DESCRIPTION
This should help fix one of the more annoying issues with the jenkins
pipeline step docs where the step links never work. If the title
contains invalid section id chars at the begging of the string the result
would be a leading separator char.

For example if the title is `<code>foo</code>: bar` the resulting anchor
should be "foo-bar" not "-foo-bar".