### PR TITLE
Asciidoc section anchor

### DIFF
--- a/lib/awestruct/ibeams/asciidoc_sections.rb
+++ b/lib/awestruct/ibeams/asciidoc_sections.rb
@@ -95,7 +95,7 @@ module Awestruct
       def section_anchor(title, in_document)
         prefix = in_document.attributes['idprefix'] || ''
         separator = in_document.attributes['idseparator'] || '-'
-        title = title.downcase.gsub(Asciidoctor::InvalidSectionIdCharsRx, separator)
+        title = title.downcase.gsub(Asciidoctor::InvalidSectionIdCharsRx, '')
 
         return [
           prefix,

--- a/lib/awestruct/ibeams/asciidoc_sections.rb
+++ b/lib/awestruct/ibeams/asciidoc_sections.rb
@@ -99,7 +99,7 @@ module Awestruct
 
         return [
           prefix,
-          title.tr_s(" ._-", separator).chomp(separator),
+          title.tr_s(" ._-", separator).chomp(separator).delete_prefix(separator),
         ].join('')
       end
     end

--- a/spec/awestruct/ibeams/asciidoc_sections_spec.rb
+++ b/spec/awestruct/ibeams/asciidoc_sections_spec.rb
@@ -45,6 +45,12 @@ describe Awestruct::IBeams::AsciidocSections do
           pipeline.section_anchor('RSpec!', doc)
         ).to eql('rspec')
       end
+
+      it 'should delete leading separator' do
+        expect(
+          pipeline.section_anchor('<code>deleteDir</code>: Recursively delete the current directory from the workspace', doc)
+        ).to eql('deletedir-recursively-delete-the-current-directory-from-the-workspace')
+      end
     end
 
 

--- a/spec/awestruct/ibeams/asciidoc_sections_spec.rb
+++ b/spec/awestruct/ibeams/asciidoc_sections_spec.rb
@@ -51,6 +51,12 @@ describe Awestruct::IBeams::AsciidocSections do
           pipeline.section_anchor('<code>deleteDir</code>: Recursively delete the current directory from the workspace', doc)
         ).to eql('deletedir-recursively-delete-the-current-directory-from-the-workspace')
       end
+
+      it 'should skip forbidden characters' do
+        expect(
+          pipeline.section_anchor('<code>step([$class: \'BuildScanner\'])</code>: Acunetix', doc)
+        ).to eql('stepclass-buildscanner-acunetix')
+      end
     end
 
 


### PR DESCRIPTION
Extends https://github.com/jenkins-infra/awestruct-ibeams/pull/3 by adding support for headings including brackets and dollars, like https://jenkins.io/doc/pipeline/steps/acunetix/#stepclass-buildscanner-acunetix
making the code compatible with https://github.com/asciidoctor/asciidoctor/blob/master/lib/asciidoctor/section.rb#L201